### PR TITLE
fix(bridge/framework/qbox): ids not being given

### DIFF
--- a/bridge/framework/qbox.lua
+++ b/bridge/framework/qbox.lua
@@ -47,7 +47,8 @@ local function CreateMetaLicense(src, itemTable)
                 mugShot = 'none',
                 badge = GetBadge(src, v)
             }
-            player.Functions.AddItem(v, 1, false, metadata)
+
+            exports.ox_inventory:AddItem(src, v, 1, metadata)
         end
     else
         print("Invalid parameter type")

--- a/bridge/framework/qbox.lua
+++ b/bridge/framework/qbox.lua
@@ -68,7 +68,7 @@ local function GetMetaLicense(src, itemTable)
     end
 
     if type(itemTable) == "table" then
-        for _, v in pairs(itemTable) do
+        for _, v in pairs(itemTable) do --luacheck: ignore
             metadata = {
                 cardtype = v,
                 citizenid = player.PlayerData.citizenid,

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,5 +1,5 @@
 return {
-    
+
     idCardSettings = {
         closeKey = 'Backspace',
         autoClose = {

--- a/main/client.lua
+++ b/main/client.lua
@@ -23,7 +23,7 @@ end
 
 -- Send config data to the nui
 local function sendConfigData()
-    SendNUIMessage({type = 'configData', configData = Config})
+    SendNUIMessage({type = 'configData', configData = sharedConfig})
 end
 
 -- Events

--- a/main/server.lua
+++ b/main/server.lua
@@ -4,7 +4,7 @@ local ox_inventory = exports.ox_inventory
 
 function NewMetaDataLicense(src, itemName)
     local newMetaDataItem = ox_inventory:Search(src, 1, itemName)
-    for _, v in pairs(newMetaDataItem) do
+    for _, v in pairs(newMetaDataItem) do --luacheck: ignore
         newMetaDataItem = v
         break
     end


### PR DESCRIPTION
## Description

Fixes an issue where IDs were not actually being given and the metadata field was throwing errors

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
