### PR TITLE
Add items to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@
 ### Optional
 * **[um-idcard-menu](https://github.com/alp1x/um-idcard-menu)**
 
+## Card items (ox_inventory)
+Add the following to your `ox_inventory/data/items.lua`.
+
+```lua
+['id_card'] = {
+    label = 'Identification Card',
+},
+
+['driver_license'] = {
+    label = 'Drivers License',
+},
+
+['weaponlicense'] = {
+    label = 'Weapon License',
+},
+
+['lawyerpass'] = {
+    label = 'Lawyer Pass',
+},
+```
 
 ## Contributors
 <a href="https://github.com/alp1x/um-idcard/graphs/contributors">


### PR DESCRIPTION
Short term solution in hopes that people actually read the README. 

When qbx fully cleared the deprecated items.lua here: https://github.com/Qbox-project/qbx_core/commit/2c6d7dc8d25b811e0c185b8ffd95a5ef818771d5 these card items no longer get converted and inserted into ox inventory.

Obviously the better way would be to insert them elsewhere if they don't exist or make a PR to ox inventory to have them as default which is unlikely to be accepted.